### PR TITLE
Add logic to account for no ancestor elements.

### DIFF
--- a/modules/islandora_collection_permissions/includes/handler.class.inc
+++ b/modules/islandora_collection_permissions/includes/handler.class.inc
@@ -155,7 +155,9 @@ class IslandoraCollectionPermissionsHandler {
           break;
         }
 
-        $this->pidsToExamine = array_merge($this->pidsToExamine, $this->getRelatedPids($operand_in));
+        if (is_array($operand_in) && count($operand_in)) {
+          $this->pidsToExamine = array_merge($this->pidsToExamine, $this->getRelatedPids($operand_in));
+        }
       }
     }
 
@@ -237,7 +239,9 @@ class IslandoraCollectionPermissionsHandler {
     if ($qp->islandoraSolrResult['response']['numFound'] === 0) {
       return FALSE;
     }
-    return array_map($to_pid, $qp->islandoraSolrResult['response']['objects'][0]['solr_doc'][$ancestor_field]);
+    if (count($qp->islandoraSolrResult['response']['objects'])) {
+      return array_map($to_pid, $qp->islandoraSolrResult['response']['objects'][0]['solr_doc'][$ancestor_field]);
+    }
   }
 
 }


### PR DESCRIPTION
When browsing a collection past page 1 (e.g. on page 2), the following errors appear:

```
  Notice: Undefined offset: 0 in IslandoraCollectionPermissionsHandler->querySolrForAncestors() (line 240 of /var/www/html/sites/all/modules/islandora_access_override/modules/islandora_collection_permissions/includes/handler.class.inc).
    Warning: array_map(): Argument #2 should be an array in IslandoraCollectionPermissionsHandler->querySolrForAncestors() (line 240 of /var/www/html/sites/all/modules/islandora_access_override/modules/islandora_collection_permissions/includes/handler.class.inc).
    Warning: array_merge(): Argument #2 is not an array in IslandoraCollectionPermissionsHandler->getActivePermissionedCollection() (line 158 of /var/www/html/sites/all/modules/islandora_access_override/modules/islandora_collection_permissions/includes/handler.class.inc).
    Warning: array_shift() expects parameter 1 to be array, null given in IslandoraCollectionPermissionsHandler->getActivePermissionedCollection() (line 143 of /var/www/html/sites/all/modules/islandora_access_override/modules/islandora_collection_permissions/includes/handler.class.inc).
```

I am not sure what condition triggered these errors, but doing some preemptive checks eliminates them.