### PR TITLE
Don't load related objects if they don't exist

### DIFF
--- a/modules/islandora_collection_permissions/includes/handler.class.inc
+++ b/modules/islandora_collection_permissions/includes/handler.class.inc
@@ -196,8 +196,8 @@ class IslandoraCollectionPermissionsHandler {
 
       foreach (array('isMemberOfCollection', 'isMemberOf') as $pred) {
         foreach ($object->relationships->get(FEDORA_RELS_EXT_URI, $pred) as $relation) {
-          $test = islandora_object_load($relation['object']['value']);
-          if (is_object($test)) {
+          $related_object = islandora_object_load($relation['object']['value']);
+          if (is_object($related_object)) {
             $related[] = $relation['object']['value'];
           }
         }

--- a/modules/islandora_collection_permissions/includes/handler.class.inc
+++ b/modules/islandora_collection_permissions/includes/handler.class.inc
@@ -191,20 +191,24 @@ class IslandoraCollectionPermissionsHandler {
     }
 
     $object = islandora_object_load($pid);
-    $related = array();
+    if (is_object($object)) {
+      $related = array();
 
-    foreach (array('isMemberOfCollection', 'isMemberOf') as $pred) {
-      foreach ($object->relationships->get(FEDORA_RELS_EXT_URI, $pred) as $relation) {
-        $related[] = $relation['object']['value'];
+      foreach (array('isMemberOfCollection', 'isMemberOf') as $pred) {
+        foreach ($object->relationships->get(FEDORA_RELS_EXT_URI, $pred) as $relation) {
+          $test = islandora_object_load($relation['object']['value']);
+          if (is_object($test)) {
+            $related[] = $relation['object']['value'];
+          }
+        }
       }
+
+      $related = array_unique($related);
+      sort($related);
+
+      return $related;
     }
-
-    $related = array_unique($related);
-    sort($related);
-
-    return $related;
   }
-
   /**
    * Helper; hit Solr for ancestors of the given PID.
    *

--- a/modules/islandora_collection_permissions/includes/handler.class.inc
+++ b/modules/islandora_collection_permissions/includes/handler.class.inc
@@ -191,9 +191,8 @@ class IslandoraCollectionPermissionsHandler {
     }
 
     $object = islandora_object_load($pid);
+    $related = array();
     if (is_object($object)) {
-      $related = array();
-
       foreach (array('isMemberOfCollection', 'isMemberOf') as $pred) {
         foreach ($object->relationships->get(FEDORA_RELS_EXT_URI, $pred) as $relation) {
           $related_object = islandora_object_load($relation['object']['value']);
@@ -205,10 +204,10 @@ class IslandoraCollectionPermissionsHandler {
 
       $related = array_unique($related);
       sort($related);
-
-      return $related;
     }
+    return $related;
   }
+
   /**
    * Helper; hit Solr for ancestors of the given PID.
    *


### PR DESCRIPTION
Fixes the 500 error in #9: checks to see if the related objects actually exist before loading them into the related objects array.